### PR TITLE
1753

### DIFF
--- a/Baekjoon/1753/Main.java
+++ b/Baekjoon/1753/Main.java
@@ -1,0 +1,92 @@
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class Main {
+    private static final int INF = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int[] input = Arrays.stream(reader.readLine().split(" "))
+              .mapToInt(Integer::parseInt)
+              .toArray();
+        int V = input[0];
+        int E = input[1];
+
+        int K = Integer.parseInt(reader.readLine());
+
+        List<Edge>[] graph = new ArrayList[V + 1];
+        for (int i = 1; i <= V; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < E; i++) {
+            int[] edgeInfo = Arrays.stream(reader.readLine().split(" "))
+              .mapToInt(Integer::parseInt)
+              .toArray();
+            int u = edgeInfo[0];
+            int v = edgeInfo[1];
+            int w = edgeInfo[2];
+            graph[u].add(new Edge(v, w));
+        }
+
+        int[] dist = new int[V + 1];
+        Arrays.fill(dist, INF);
+        dist[K] = 0;
+
+        PriorityQueue<Node> queue = new PriorityQueue<>();
+        queue.offer(new Node(K, 0));
+
+        while (!queue.isEmpty()) {
+            Node cur = queue.poll();
+            if (cur.distance > dist[cur.vertex]) { // 현재 노드의 거리가 이미 최단 거리보다 크면 무시
+                continue;
+            }
+            for (Edge e : graph[cur.vertex]) {
+                int next = e.to;
+                int nd = cur.distance + e.weight;
+                if (nd < dist[next]) {
+                    dist[next] = nd;
+                    queue.offer(new Node(next, nd));
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= V; i++) {
+            if (dist[i] == INF) {
+                sb.append("INF\n");
+            } else {
+                sb.append(dist[i]).append('\n');
+            }
+        }
+        writer.write(sb.toString());
+
+        reader.close();
+        writer.close();
+    }
+
+    static class Node implements Comparable<Node> {
+        int vertex;
+        int distance;
+        Node(int vertex, int distance) {
+            this.vertex = vertex;
+            this.distance = distance;
+        }
+        @Override
+        public int compareTo(Node o) {
+            return Integer.compare(this.distance, o.distance);
+        }
+    }
+
+    static class Edge {
+        int to;
+        int weight;
+        Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+}


### PR DESCRIPTION
# 문제
[백준-1753](https://www.acmicpc.net/problem/1753)
(n 위치에 번호 넣기

# 난이도
골드4

# 풀이 날짜
2025-06-23

# 사용한 언어
Java

# 후기
다익스트라 알고리즘을 통해 시간복잡도를 더 줄였어야 했는데 실패했다.
결국은 답을 보고 풀었는데 다시 시도해서 해결해 보는걸로
[다익스트라 정리](https://velog.io/@tadap/%EB%8B%A4%EC%9D%B5%EC%8A%A4%ED%8A%B8%EB%9D%BC)

# 구현 아이디어
1.  방문 정점 0 처리 나머지는 무한대에 가깝게 초기화
2. 이후 처음부터 연결된 노드를 방문하며 값을 변경시킨다 이때
    1. 확정되지 않은 정점중, 거리가 가장 짧은 정점부터 방문한다.
    2. 해당 정점을 확정 처리하고 인접 간선에 대해 완화(현재 정점 (확정된 길이) 에서 나가는 모든 vertex에 대해 더 짧은 값이 있는지 확인)

# 핵심 로직
- 다익스트라 알고리즘을 통해 시간 복잡도 최소화

# 시간복잡도 분석
O(ElogV)
