### PR TITLE
23366

### DIFF
--- a/Baekjoon/23366/Main.java
+++ b/Baekjoon/23366/Main.java
@@ -1,0 +1,107 @@
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class Main{
+    public static void main(String[] args)throws IOException{
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int[] initFirstLine = Arrays.stream(reader.readLine().split(" "))
+            .mapToInt(Integer::parseInt)
+            .toArray();
+
+        int n = initFirstLine[0]; // number of country
+        int m = initFirstLine[1]; // number of borders
+
+        HashMap<Integer, List<Edge>> graph = new HashMap<>();
+        for (int i = 1; i <= n; i++) {
+            graph.put(i, new ArrayList<>());
+        }
+
+        int[] initSecondLine = Arrays.stream(reader.readLine().split(" "))
+            .mapToInt(Integer::parseInt)
+            .toArray();
+
+        int startCountryNumber = initSecondLine[0]; // 시작점
+        int endCountryNumber = initSecondLine[1]; // 끝점
+        int numberOfCandy = initSecondLine[2]; // 사탕의 수
+
+        for (int i = 0; i < m; i++) {
+            int[] borderInfo = Arrays.stream(reader.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+
+            int startCountryPoint = borderInfo[0]; // 시작점
+            int endCountryPoint = borderInfo[1]; // 끝점
+            int taxPercentage = borderInfo[2]; // 세금 퍼센트
+
+            graph.get(startCountryPoint).add(new Edge(taxPercentage, endCountryPoint));
+            graph.get(endCountryPoint).add(new Edge(taxPercentage, startCountryPoint));
+        }
+
+        int result = solve(n, graph, startCountryNumber, endCountryNumber, numberOfCandy);
+        writer.write(String.valueOf(result));
+        writer.flush();
+
+        reader.close();
+        writer.close();
+    }
+
+    public static int solve(int n, Map<Integer, List<Edge>> graph, int start, int target, int initCandy){
+
+        int[] candyStatus = new int[n + 1];
+        Arrays.fill(candyStatus, -1);
+
+        PriorityQueue<Node> queue = new PriorityQueue<>();
+        candyStatus[start] = initCandy;
+        queue.offer(new Node(start, initCandy));
+
+        while (!queue.isEmpty()) {
+            Node visit = queue.poll();
+
+            if (visit.countryNumber == target) {
+                return visit.candy;
+            }
+            if (candyStatus[visit.countryNumber] > visit.candy) {
+                continue;
+            }
+
+            for (Edge edge : graph.get(visit.countryNumber)) {
+                long total = (long)visit.candy * edge.taxPercentage;
+                int taxToPay = (int)((total + 99) / 100);
+                int nextCandy = visit.candy - taxToPay;
+                if (nextCandy > candyStatus[edge.nextNode]) {
+                    candyStatus[edge.nextNode] = nextCandy;
+                    queue.offer(new Node(edge.nextNode, nextCandy));
+                }
+            }
+        }
+        return 0;
+    }
+
+    public static class Node implements Comparable<Node>{
+        int countryNumber;
+        int candy;
+
+        public Node(int countryNumber, int candy) {
+            this.countryNumber = countryNumber;
+            this.candy = candy;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return Integer.compare(o.candy, this.candy);
+        }
+    }
+
+    public static class Edge{
+        int taxPercentage;
+        int nextNode;
+
+        public Edge(int taxPercentage, int nextNode) {
+            this.taxPercentage = taxPercentage;
+            this.nextNode = nextNode;
+        }
+    }
+}


### PR DESCRIPTION
# 문제
[백준-23366](https://www.acmicpc.net/problem/23366)

# 난이도
골드4

# 풀이 날짜
2025-06-28 ~ 29

# 사용한 언어
Java

# 후기
먼저 DFS로 풀었는데 타입아웃이 났다. 아무래도  `2*10^5` 까지 Edge가 있다보니 문제였던것 같다
그리고 다익스트라로 푸는건 답지의 도움을 받았다... 원래 어제풀어야할꺼 오늘 풀었으니까 오늘은 그냥 다익스트라 하나 더 풀어 보는걸로

# 문제 접근
- 모든 Node를 초기화 하고 Edge정보를 Node별로 저장을 한다
- 이후 최초 방문노드부터 방문하며 관련된 Edge들을 방문하여 새로운 노드를 검사한다.
- 우선순위 큐를 사용해 현재 들고 있는 사탕이 많은 상태부터 처리한다

# 핵심 로직
- 다익스트라 이용하여 로직 검사시간 최소화

# 시간복잡도 분석

